### PR TITLE
SSL/TLS support

### DIFF
--- a/postgres-native-tls/Cargo.toml
+++ b/postgres-native-tls/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
-name = "postgres-native-tls"
-version = "0.5.0"
+name = "yb-postgres-native-tls"
+version = "0.5.0-yb-1"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
-description = "TLS support for tokio-postgres via native-tls"
-repository = "https://github.com/sfackler/rust-postgres"
+homepage = "https://www.yugabyte.com/"
+documentation = "https://docs.yugabyte.com/stable/drivers-orms/rust/yb-rust-postgres"
+description = "TLS support for yb-tokio-postgres via native-tls"
+repository = "https://github.com/yugabyte/rust-postgres"
 readme = "../README.md"
 
 [badges]
-circle-ci = { repository = "sfackler/rust-postgres" }
+circle-ci = { repository = "yugabyte/rust-postgres" }
 
 [features]
 default = ["runtime"]

--- a/postgres-native-tls/Cargo.toml
+++ b/postgres-native-tls/Cargo.toml
@@ -13,15 +13,15 @@ circle-ci = { repository = "sfackler/rust-postgres" }
 
 [features]
 default = ["runtime"]
-runtime = ["tokio-postgres/runtime"]
+runtime = ["yb-tokio-postgres/runtime"]
 
 [dependencies]
 native-tls = "0.2"
 tokio = "1.0"
 tokio-native-tls = "0.3"
-tokio-postgres = { version = "0.7.0", default-features = false }
+yb-tokio-postgres = "0.7.10-yb-1-beta"
 
 [dev-dependencies]
 futures-util = "0.3"
 tokio = { version = "1.0", features = ["macros", "net", "rt"] }
-postgres = "0.19.0" 
+yb-postgres = "0.19.7-yb-1-beta" 

--- a/postgres-native-tls/src/lib.rs
+++ b/postgres-native-tls/src/lib.rs
@@ -17,7 +17,7 @@
 //!     .build()?;
 //! let connector = MakeTlsConnector::new(connector);
 //!
-//! let connect_future = tokio_postgres::connect(
+//! let connect_future = yb_tokio_postgres::connect(
 //!     "host=localhost user=postgres sslmode=require",
 //!     connector,
 //! );
@@ -43,7 +43,7 @@
 //!     .build()?;
 //! let connector = MakeTlsConnector::new(connector);
 //!
-//! let client = postgres::Client::connect(
+//! let client = yb_postgres::Client::connect(
 //!     "host=localhost user=postgres sslmode=require",
 //!     connector,
 //! )?;
@@ -58,10 +58,10 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, BufReader, ReadBuf};
-use tokio_postgres::tls;
+use yb_tokio_postgres::tls;
 #[cfg(feature = "runtime")]
-use tokio_postgres::tls::MakeTlsConnect;
-use tokio_postgres::tls::{ChannelBinding, TlsConnect};
+use yb_tokio_postgres::tls::MakeTlsConnect;
+use yb_tokio_postgres::tls::{ChannelBinding, TlsConnect};
 
 #[cfg(test)]
 mod test;

--- a/postgres-openssl/Cargo.toml
+++ b/postgres-openssl/Cargo.toml
@@ -13,15 +13,15 @@ circle-ci = { repository = "sfackler/rust-postgres" }
 
 [features]
 default = ["runtime"]
-runtime = ["tokio-postgres/runtime"]
+runtime = ["yb-tokio-postgres/runtime"]
 
 [dependencies]
 openssl = "0.10"
 tokio = "1.0"
 tokio-openssl = "0.6"
-tokio-postgres = { version = "0.7.0", default-features = false }
+yb-tokio-postgres = "0.7.10-yb-1-beta"
 
 [dev-dependencies]
 futures-util = "0.3"
 tokio = { version = "1.0", features = ["macros", "net", "rt"] }
-postgres = "0.19.0"
+yb-postgres = "0.19.7-yb-1-beta"

--- a/postgres-openssl/Cargo.toml
+++ b/postgres-openssl/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
-name = "postgres-openssl"
-version = "0.5.0"
+name = "yb-postgres-openssl"
+version = "0.5.0-yb-1"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
-description = "TLS support for tokio-postgres via openssl"
-repository = "https://github.com/sfackler/rust-postgres"
+homepage = "https://www.yugabyte.com/"
+documentation = "https://docs.yugabyte.com/stable/drivers-orms/rust/yb-rust-postgres"
+description = "TLS support for yb-tokio-postgres via openssl"
+repository = "https://github.com/yugabyte/rust-postgres"
 readme = "../README.md"
 
 [badges]
-circle-ci = { repository = "sfackler/rust-postgres" }
+circle-ci = { repository = "yugabyte/rust-postgres" }
 
 [features]
 default = ["runtime"]

--- a/postgres-openssl/src/lib.rs
+++ b/postgres-openssl/src/lib.rs
@@ -13,7 +13,7 @@
 //! builder.set_ca_file("database_cert.pem")?;
 //! let connector = MakeTlsConnector::new(builder.build());
 //!
-//! let connect_future = tokio_postgres::connect(
+//! let connect_future = yb_tokio_postgres::connect(
 //!     "host=localhost user=postgres sslmode=require",
 //!     connector,
 //! );
@@ -35,7 +35,7 @@
 //! builder.set_ca_file("database_cert.pem")?;
 //! let connector = MakeTlsConnector::new(builder.build());
 //!
-//! let client = postgres::Client::connect(
+//! let client = yb_postgres::Client::connect(
 //!     "host=localhost user=postgres sslmode=require",
 //!     connector,
 //! )?;
@@ -65,10 +65,10 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, BufReader, ReadBuf};
 use tokio_openssl::SslStream;
-use tokio_postgres::tls;
+use yb_tokio_postgres::tls;
 #[cfg(feature = "runtime")]
-use tokio_postgres::tls::MakeTlsConnect;
-use tokio_postgres::tls::{ChannelBinding, TlsConnect};
+use yb_tokio_postgres::tls::MakeTlsConnect;
+use yb_tokio_postgres::tls::{ChannelBinding, TlsConnect};
 
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
To use SSL\TLS with YugabyteDB rust driver, we would have to release YugabyteDB specific versions of postgres-openssl and  postgres-native-tls.

Changes:

- postgres -> yb-postgres in postgres-native-tls and postgres-openssl
- tokio-postgres -> yb-tokio-postgres in postgres-native-tls and postgres-openssl
- Cargo.toml changes to release yb-postgres-native-tls and yb-postgres-openssl