### PR TITLE
Remove logger initialization

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -63,7 +63,6 @@ tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.8.5"
 whoami = "1.4.1"
 lazy_static = "1.4.0"
-env_logger = "0.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 socket2 = { version = "0.5", features = ["all"] }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -12,7 +12,6 @@ use crate::tls::TlsConnect;
 #[cfg(feature = "runtime")]
 use crate::Socket;
 use crate::{Client, Connection, Error};
-use env_logger::{Builder, Target};
 use std::borrow::Cow;
 use std::collections::HashMap;
 #[cfg(unix)]
@@ -25,21 +24,9 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::str;
 use std::str::FromStr;
-use std::sync::Once;
 use std::time::Duration;
 use std::{error, fmt, iter, mem};
 use tokio::io::{AsyncRead, AsyncWrite};
-
-static INIT: Once = Once::new();
-
-fn logger_setup() {
-    let mut builder = Builder::from_default_env();
-    builder.target(Target::Stdout);
-
-    INIT.call_once(|| {
-        builder.init();
-    });
-}
 
 /// Properties required of a session.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -895,7 +882,6 @@ impl Config {
         T: MakeTlsConnect<Socket>,
     {
         if self.load_balance == true {
-            logger_setup();
             yb_connect(tls, self).await
         } else {
             connect(tls, self).await


### PR DESCRIPTION
This PR removes the logger initialization and `env_logger` dependency from `yb_tokio_postgres`. 

Loggers should only be initialized in executables, never in libraries. `yb_tokio_postgres` is a library, and therefore should not be initializing a logger.

The logger that is initialized in the `yb_tokio_postgres::connect` function interferes with any logger that a consumer is trying to initialize (e.g. our app that depends on YugabyteDB). According to the crate `log`'s documentation, loggers should only be initialized once in the executable source code (not in libraries) and libraries should only use the `log` macros. See [`In libraries`](https://docs.rs/log/0.4.22/log/#in-libraries) and [`In executables`](https://docs.rs/log/0.4.22/log/#in-executables) subsections.