### PR TITLE
Load balancing connections among nodes of RR cluster.

### DIFF
--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -82,7 +82,8 @@ use yb_tokio_postgres::{Error, Socket};
 ///     `disable`, hosts and addresses will be tried in the order provided. If set to `random`, hosts will be tried
 ///     in a random order, and the IP addresses resolved from a hostname will also be tried in a random order. Defaults
 ///     to `disable`.
-/// * `load_balance` -  It expects true/false as its possible values. Default value is true.
+/// * `load_balance` -  Defaults to upstream driver behavior unless set to one of the allowed values (true or any, only-rr, only-primary,
+///     prefer-primary, prefer-rr and false) other than 'false'.
 /// * `topology_keys` - It takes a comma separated geo-location values. A single geo-location can be given as 'cloud.region.zone'.
 ///     Multiple geo-locations too can be specified, separated by comma (,). Each placement value can be suffixed with a colon (:)
 ///     followed by a preference value between 1 and 10. A preference value of :1 means it is a primary placement. A preference
@@ -436,7 +437,7 @@ impl Config {
     /// Sets the load balance parameter.
     ///
     /// Defaults to false.
-    pub fn load_balance(&mut self, load_balance: bool) -> &mut Config {
+    pub fn load_balance(&mut self, load_balance: &str) -> &mut Config {
         self.config.load_balance(load_balance);
         self
     }
@@ -444,7 +445,7 @@ impl Config {
     /// YugabyteDB Specific.
     ///
     /// Gets the load balance value
-    pub fn get_load_balance(&self) -> bool {
+    pub fn get_load_balance(&self) -> String {
         self.config.get_load_balance()
     }
 

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "runtime")]
 use crate::connect::connect;
-use crate::connect::{yb_connect, PLACEMENT_INFO_MAP};
+use crate::connect::yb_connect;
 use crate::connect_raw::connect_raw;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::keepalive::KeepaliveConfig;
@@ -147,7 +147,8 @@ pub enum Host {
 ///     `disable`, hosts and addresses will be tried in the order provided. If set to `random`, hosts will be tried
 ///     in a random order, and the IP addresses resolved from a hostname will also be tried in a random order. Defaults
 ///     to `disable`.
-/// * `load_balance` -  It expects true/false as its possible values. Default value is true.
+/// * `load_balance` -  Defaults to upstream driver behavior unless set to one of the allowed values (true or any, only-rr, only-primary,
+///     prefer-primary, prefer-rr and false) other than 'false'.
 /// * `topology_keys` - It takes a comma separated geo-location values. A single geo-location can be given as 'cloud.region.zone'.
 ///     Multiple geo-locations too can be specified, separated by comma (,). Each placement value can be suffixed with a colon (:)
 ///     followed by a preference value between 1 and 10. A preference value of :1 means it is a primary placement. A preference
@@ -226,7 +227,7 @@ pub struct Config {
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) load_balance_hosts: LoadBalanceHosts,
     /// YugabyteDB Specific
-    pub(crate) load_balance: bool,
+    pub(crate) load_balance: String,
     pub(crate) topology_keys: HashMap<i64, Vec<String>>,
     pub(crate) yb_servers_refresh_interval: Duration,
     pub(crate) fallback_to_topology_keys_only: bool,
@@ -264,7 +265,7 @@ impl Config {
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
             load_balance_hosts: LoadBalanceHosts::Disable,
-            load_balance: false,
+            load_balance: String::from("false"),
             topology_keys: HashMap::new(),
             yb_servers_refresh_interval: Duration::new(300, 0),
             fallback_to_topology_keys_only: false,
@@ -554,16 +555,16 @@ impl Config {
     /// Sets the load balance parameter.
     ///
     /// Defaults to false.
-    pub fn load_balance(&mut self, load_balance: bool) -> &mut Config {
-        self.load_balance = load_balance;
+    pub fn load_balance(&mut self, load_balance: &str) -> &mut Config {
+        self.load_balance = load_balance.to_lowercase();
         self
     }
 
     /// YugabyteDB Specific.
     ///
     /// Gets the load balance value
-    pub fn get_load_balance(&self) -> bool {
-        self.load_balance
+    pub fn get_load_balance(&self) -> String {
+        self.load_balance.clone()
     }
 
     /// YugabyteDB Specific.
@@ -652,6 +653,20 @@ impl Config {
         self.failed_host_reconnect_delay_secs
     }
 
+    ///Check if the given load_balnce value if one of the allowed values.
+    pub fn is_lb_valid(&self, lb: &str) -> bool {
+        match lb.to_lowercase().as_str(){
+            "only-rr" => return true,
+            "only-primary"=> return true,
+            "prefer-primary"=> return true,
+            "prefer-rr"=> return true,
+            "any"=> return true,
+            "true"=> return true,
+            "false"=> return true,
+            _=>return false,
+        };
+    }
+
     ///Check if a given zone in Topology keys is valid
     pub fn is_valid(&self, zone: &str) -> bool {
         let mut zones: Vec<&str> = zone.split(":").collect();
@@ -673,13 +688,6 @@ impl Config {
             if priorityvalue < 1 || priorityvalue > 10 {
                 return false;
             }
-        }
-        let placementinfo = PLACEMENT_INFO_MAP.lock().unwrap().clone();
-        if placement[2] != "*" {
-            placementinfo.contains_key(zones[0]);
-        } else {
-            let starplacement: String = placement[0].to_owned() + placement[1];
-            placementinfo.contains_key(&starplacement);
         }
         true
     }
@@ -820,10 +828,11 @@ impl Config {
                 self.load_balance_hosts(load_balance_hosts);
             }
             "load_balance" => {
-                let load_balance = value
-                    .parse::<bool>()
-                    .map_err(|_| Error::config_parse(Box::new(InvalidValue("load_balance"))))?;
-                self.load_balance(load_balance);
+                if self.is_lb_valid(value) {
+                    self.load_balance(value);
+                } else {
+                    return Err(Error::config_parse(Box::new(InvalidValue("load_balance"))));
+                }
             }
             "topology_keys" => {
                 for topology_keys in value.split(',') {
@@ -881,7 +890,7 @@ impl Config {
     where
         T: MakeTlsConnect<Socket>,
     {
-        if self.load_balance == true {
+        if self.load_balance != "false" {
             yb_connect(tls, self).await
         } else {
             connect(tls, self).await

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -15,14 +15,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::task::Poll;
 use std::time::Instant;
-use std::{cmp, io};
+use std::{cmp, io, vec};
 use tokio::net;
 use tokio::sync::Mutex as TokioMutex;
 
 lazy_static! {
     static ref CONNECTION_COUNT_MAP: Mutex<HashMap<Host, i64>> = {
         let mut m = HashMap::new();
-        let host_list = HOST_INFO.lock().unwrap().clone();
+        let host_list_primary = HOST_INFO_PRIMAY.lock().unwrap().clone();
+        let host_list_rr = HOST_INFO_RR.lock().unwrap().clone();
+        let host_list = vec![host_list_primary, host_list_rr].concat();
         let size = host_list.len();
         for i in 0..size {
             let host = host_list.get(i);
@@ -36,7 +38,11 @@ lazy_static! {
         let m = Instant::now();
         TokioMutex::new(m)
     };
-    static ref HOST_INFO: Mutex<Vec<Host>> = {
+    static ref HOST_INFO_PRIMAY: Mutex<Vec<Host>> = {
+        let m = Vec::new();
+        Mutex::new(m)
+    };
+    static ref HOST_INFO_RR: Mutex<Vec<Host>> = {
         let m = Vec::new();
         Mutex::new(m)
     };
@@ -44,7 +50,11 @@ lazy_static! {
         let m = HashMap::new();
         Mutex::new(m)
     };
-    pub(crate) static ref PLACEMENT_INFO_MAP: Mutex<HashMap<String, Vec<Host>>> = {
+    pub(crate) static ref PLACEMENT_INFO_MAP_PRIMARY: Mutex<HashMap<String, Vec<Host>>> = {
+        let m = HashMap::new();
+        Mutex::new(m)
+    };
+    pub(crate) static ref PLACEMENT_INFO_MAP_RR: Mutex<HashMap<String, Vec<Host>>> = {
         let m = HashMap::new();
         Mutex::new(m)
     };
@@ -177,10 +187,10 @@ where
     loop {
         let newhost = get_least_loaded_server(config);
         let mut host = match newhost {
-            Some(host) => host,
-            None => {
-                // Fallback to original behaviour
-                return connect(tls, config).await;
+            Ok(host) => host,
+            Err(e) => {
+                // Throw the error
+                return Err(e);
             }
         };
 
@@ -262,14 +272,36 @@ pub(crate) fn decrease_connection_count(host: Host) {
     }
 }
 
-fn get_least_loaded_server(config: &Config) -> Option<Host> {
+fn get_least_loaded_server(config: &Config) -> Result<Host, Error> {
     let conn_map = CONNECTION_COUNT_MAP.lock().unwrap().clone();
-    let host_list = HOST_INFO.lock().unwrap().clone();
+    let host_list_primary = HOST_INFO_PRIMAY.lock().unwrap().clone();
+    let host_list_rr = HOST_INFO_RR.lock().unwrap().clone();
     let failed_host_list = FAILED_HOSTS.lock().unwrap().clone();
-    let placement_info_map = PLACEMENT_INFO_MAP.lock().unwrap().clone();
-
-    let mut min_count = MAX;
+    let placement_info_map_primary = PLACEMENT_INFO_MAP_PRIMARY.lock().unwrap().clone();
+    let placement_info_map_rr = PLACEMENT_INFO_MAP_RR.lock().unwrap().clone();
     let mut least_host: Vec<Host> = Vec::new();
+
+    let mut host_list: Vec<Host> = Vec::new();
+    let mut placement_info_map: HashMap<String, Vec<Host>> = HashMap::new();
+
+    if config.load_balance == "only-rr" || config.load_balance == "prefer-rr" {
+        host_list = host_list_rr.clone();
+        placement_info_map = placement_info_map_rr.clone();
+    } else if config.load_balance == "only-primary" || config.load_balance == "prefer-primary" {
+        host_list = host_list_primary.clone();
+        placement_info_map = placement_info_map_primary.clone();
+    } else {
+        host_list = host_list_rr.clone();
+        placement_info_map = placement_info_map_rr.clone();
+        host_list.extend(host_list_primary.clone());
+        for (key, value) in placement_info_map_primary {
+            if let Some(vec) = placement_info_map.get_mut(&key) {
+                vec.extend(value);
+            } else {
+                placement_info_map.insert(key, value);
+            }
+        }
+    }
 
     if !config.topology_keys.is_empty() {
         for i in 0..config.topology_keys.len() as i64 {
@@ -291,50 +323,33 @@ fn get_least_loaded_server(config: &Config) -> Option<Host> {
                     }
                 }
             }
-            for host in server.iter() {
-                if !failed_host_list.contains_key(host) {
-                    let count = conn_map.get(host);
-                    let mut counter: i64 = 0;
-                    if !count.is_none() {
-                        counter = *count.unwrap();
-                    }
-                    if min_count > counter {
-                        min_count = counter;
-                        least_host.clear();
-                        least_host.push(host.clone());
-                    } else if min_count == counter {
-                        least_host.push(host.clone());
-                    }
-                }
-            }
+            least_host = get_least_loaded_hosts(server, conn_map.clone(), failed_host_list.clone());
 
-            if min_count != MAX && least_host.len() != 0 {
+            if least_host.len() != 0 {
                 break;
             }
         }
     }
 
-    if min_count == MAX && least_host.len() == 0 {
-        if config.topology_keys.is_empty() || !config.fallback_to_topology_keys_only {
-            for i in 0..host_list.len() {
-                let host = &host_list[i];
-                if !failed_host_list.contains_key(host) {
-                    let count = conn_map.get(host);
-                    let mut counter: i64 = 0;
-                    if !count.is_none() {
-                        counter = *count.unwrap();
-                    }
-                    if min_count > counter {
-                        min_count = counter;
-                        least_host.clear();
-                        least_host.push(host.clone());
-                    } else if min_count == counter {
-                        least_host.push(host.clone());
-                    }
-                }
+    if least_host.len() == 0 {
+        if !(config.load_balance == "prefer-primary" || config.load_balance == "prefer-rr") {
+            if config.topology_keys.is_empty() || !config.fallback_to_topology_keys_only {
+                least_host = get_least_loaded_hosts(host_list, conn_map.clone(), failed_host_list.clone());
+            } else {
+                return Err(Error::connect(io::Error::new(
+                    io::ErrorKind::ConnectionRefused,
+                    "no preferred server available, fallback-to-topology-keys-only is set to true",
+                )));
             }
         } else {
-            return None;
+            least_host = get_least_loaded_hosts(host_list, conn_map.clone(), failed_host_list.clone());
+            if least_host.len() == 0 {
+                if config.load_balance == "prefer-rr"{
+                    least_host = get_least_loaded_hosts(host_list_primary, conn_map.clone(), failed_host_list.clone());
+                } else {
+                    least_host = get_least_loaded_hosts(host_list_rr, conn_map.clone(), failed_host_list.clone());
+                }
+            }
         }
     }
 
@@ -344,15 +359,42 @@ fn get_least_loaded_server(config: &Config) -> Option<Host> {
             least_host
         );
         let num = rand::thread_rng().gen_range(0..least_host.len());
-        return least_host.get(num).cloned();
+        return Ok(least_host.get(num).cloned().expect("least loaded host value is None"));
     } else {
-        return None;
+        return Err(Error::connect(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "could not find a server to connect to",
+        )));
     }
+}
+
+fn get_least_loaded_hosts(hosts: Vec<Host>, conn_map: HashMap<Host, i64>, failed_hosts: HashMap<Host, Instant>) -> Vec<Host> {
+    let mut min_count = MAX;
+    let mut least_host: Vec<Host> = Vec::new();
+    for host in hosts.iter() {
+        if !failed_hosts.contains_key(host) {
+            let count = conn_map.get(host);
+            let mut counter: i64 = 0;
+            if !count.is_none() {
+                counter = *count.unwrap();
+            }
+            if min_count > counter {
+                min_count = counter;
+                least_host.clear();
+                least_host.push(host.clone());
+            } else if min_count == counter {
+                least_host.push(host.clone());
+            }
+        }
+    }
+    return least_host
 }
 
 async fn check_and_refresh(config: &Config) -> bool {
     let mut refresh_time = LAST_TIME_META_DATA_FETCHED.lock().await;
-    let host_list = HOST_INFO.lock().unwrap().clone();
+    let host_list_primary = HOST_INFO_PRIMAY.lock().unwrap().clone();
+    let host_list_rr = HOST_INFO_RR.lock().unwrap().clone();
+    let host_list = vec![host_list_primary, host_list_rr].concat();
     if host_list.len() == 0 {
         info!("Connecting to the server for the first time");
         if let Ok((client, connection)) = connect(NoTls, config).await {
@@ -455,15 +497,18 @@ async fn refresh(client: Client, config: &Config) {
         .await
         .unwrap();
 
-    let mut host_list = HOST_INFO.lock().unwrap();
+    let mut host_list_primary = HOST_INFO_PRIMAY.lock().unwrap();
+    let mut host_list_rr = HOST_INFO_RR.lock().unwrap();
     let mut failed_host_list = FAILED_HOSTS.lock().unwrap();
-    let mut placement_info_map = PLACEMENT_INFO_MAP.lock().unwrap();
+    let mut placement_info_map_primary = PLACEMENT_INFO_MAP_PRIMARY.lock().unwrap();
+    let mut placement_info_map_rr = PLACEMENT_INFO_MAP_RR.lock().unwrap();
     let mut public_host_map = PUBLIC_HOST_MAP.lock().unwrap();
     let mut host_to_port_map = HOST_TO_PORT_MAP.lock().unwrap();
     for row in rows {
         let host_string: String = row.get("host");
         let host = Host::Tcp(host_string.to_string());
         info!("Received entry for host {:?}", host);
+        let nodetype: String = row.get("node_type");
         let portvalue: i64 = row.get("port");
         let port: u16 = portvalue as u16;
         let cloud: String = row.get("cloud");
@@ -482,10 +527,18 @@ async fn refresh(client: Client, config: &Config) {
         }
 
         if !failed_host_list.contains_key(&host) {
-            if !host_list.contains(&host) {
-                host_list.push(host.clone());
-                public_host_map.insert(host.clone(), public_ip.clone());
-                debug!("Added {:?} to host list", host.clone());
+            if nodetype == "primary" {
+                if !host_list_primary.contains(&host) {
+                    host_list_primary.push(host.clone());
+                    public_host_map.insert(host.clone(), public_ip.clone());
+                    debug!("Added {:?} to host list primary", host.clone());
+                }
+            } else {
+                if !host_list_rr.contains(&host) {
+                    host_list_rr.push(host.clone());
+                    public_host_map.insert(host.clone(), public_ip.clone());
+                    debug!("Added {:?} to host list RR", host.clone());
+                }
             }
         } else {
             if failed_host_list.get(&host).unwrap().elapsed()
@@ -496,47 +549,90 @@ async fn refresh(client: Client, config: &Config) {
                     "Marking {:?} as UP since failed-host-reconnect-delay-secs has elapsed",
                     host.clone()
                 );
-                if !host_list.contains(&host) {
-                    host_list.push(host.clone());
-                    public_host_map.insert(host.clone(), public_ip.clone());
+                if nodetype == "primary" {
+                    if !host_list_primary.contains(&host) {
+                        host_list_primary.push(host.clone());
+                        public_host_map.insert(host.clone(), public_ip.clone());
+                        debug!("Added {:?} to host list primary", host.clone());
+                    }
+                } else {
+                    if !host_list_rr.contains(&host) {
+                        host_list_rr.push(host.clone());
+                        public_host_map.insert(host.clone(), public_ip.clone());
+                        debug!("Added {:?} to host list RR", host.clone());
+                    }
                 }
                 make_connection_count_zero(host.clone());
-            } else if host_list.contains(&host) {
+            } else if host_list_primary.contains(&host) || host_list_rr.contains(&host) {
                 debug!(
                     "Treating {:?} as DOWN since failed-host-reconnect-delay-secs has not elapsed",
                     host.clone()
                 );
-                let index = host_list.iter().position(|x| *x == host).unwrap();
-                host_list.remove(index);
+                if host_list_primary.contains(&host) {
+                    let index = host_list_primary.iter().position(|x| *x == host).unwrap();
+                    host_list_primary.remove(index);
+                } else {
+                    let index = host_list_rr.iter().position(|x| *x == host).unwrap();
+                    host_list_rr.remove(index);
+                }
                 public_host_map.remove(&host);
             }
         }
 
-        if placement_info_map.contains_key(&placement_zone) {
-            let mut present_hosts = placement_info_map.get(&placement_zone).unwrap().to_vec();
-            if !present_hosts.contains(&host) {
-                present_hosts.push(host.clone());
-                placement_info_map.insert(placement_zone, present_hosts.to_vec());
+        if nodetype == "primary" {
+            if placement_info_map_primary.contains_key(&placement_zone) {
+                let mut present_hosts = placement_info_map_primary.get(&placement_zone).unwrap().to_vec();
+                if !present_hosts.contains(&host) {
+                    present_hosts.push(host.clone());
+                    placement_info_map_primary.insert(placement_zone.clone(), present_hosts.to_vec());
+                }
+            } else {
+                let mut host_vec: Vec<Host> = Vec::new();
+                host_vec.push(host.clone());
+                placement_info_map_primary.insert(placement_zone.clone(), host_vec);
             }
-        } else {
-            let mut host_vec: Vec<Host> = Vec::new();
-            host_vec.push(host.clone());
-            placement_info_map.insert(placement_zone, host_vec);
-        }
 
-        if placement_info_map.contains_key(&star_placement_zone) {
-            let mut star_present_hosts = placement_info_map
-                .get(&star_placement_zone)
-                .unwrap()
-                .to_vec();
-            if !star_present_hosts.contains(&host) {
-                star_present_hosts.push(host.clone());
-                placement_info_map.insert(star_placement_zone, star_present_hosts.to_vec());
+            if placement_info_map_primary.contains_key(&star_placement_zone) {
+                let mut star_present_hosts = placement_info_map_primary
+                    .get(&star_placement_zone)
+                    .unwrap()
+                    .to_vec();
+                if !star_present_hosts.contains(&host) {
+                    star_present_hosts.push(host.clone());
+                    placement_info_map_primary.insert(star_placement_zone.clone(), star_present_hosts.to_vec());
+                }
+            } else {
+                let mut star_host_vec: Vec<Host> = Vec::new();
+                star_host_vec.push(host.clone());
+                placement_info_map_primary.insert(star_placement_zone.clone(), star_host_vec);
             }
         } else {
-            let mut star_host_vec: Vec<Host> = Vec::new();
-            star_host_vec.push(host.clone());
-            placement_info_map.insert(star_placement_zone, star_host_vec);
+            if placement_info_map_rr.contains_key(&placement_zone) {
+                let mut present_hosts = placement_info_map_rr.get(&placement_zone).unwrap().to_vec();
+                if !present_hosts.contains(&host) {
+                    present_hosts.push(host.clone());
+                    placement_info_map_rr.insert(placement_zone, present_hosts.to_vec());
+                }
+            } else {
+                let mut host_vec: Vec<Host> = Vec::new();
+                host_vec.push(host.clone());
+                placement_info_map_rr.insert(placement_zone, host_vec);
+            }
+
+            if placement_info_map_rr.contains_key(&star_placement_zone) {
+                let mut star_present_hosts = placement_info_map_rr
+                    .get(&star_placement_zone)
+                    .unwrap()
+                    .to_vec();
+                if !star_present_hosts.contains(&host) {
+                    star_present_hosts.push(host.clone());
+                    placement_info_map_rr.insert(star_placement_zone, star_present_hosts.to_vec());
+                }
+            } else {
+                let mut star_host_vec: Vec<Host> = Vec::new();
+                star_host_vec.push(host.clone());
+                placement_info_map_rr.insert(star_placement_zone, star_host_vec);
+            }
         }
     }
 }


### PR DESCRIPTION
IDEA: [IDEA-1330](https://yugabyte.atlassian.net/browse/IDEA-1330)

Implementation details: [Doc](https://docs.google.com/document/d/1SqT7IMM5DuHav7fl_xGt8pfCMp5dnJ6-MrLVftbIows/edit#heading=h.4p1zl0z1krwh)

The connection property `load_balance` currently allows only two values, viz. `false` (the default) and `true`.

It will now also allow below five new values to be specified:
`only-rr` - Create connections only on Read Replica nodes
`only-primary`- Create connections only on primary cluster nodes
`prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
`prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
`any` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster

default value is still `false`

Other Minor changes:

- Corrected the behaviour of `fallback_to_topology_keys_only` connection property. When `fallback_to_topology_keys_only` is set to `true` and all the nodes of the specified topology_keys are down, the driver currently fallbacks to upstream driver behaviour but the driver is expected to throw an error in this case which is corrected in this PR.
- When validating topology_keys, do not match them with the placement info of the cluster.

**Testing:**
Test cases identified and listed in this [doc](https://docs.google.com/document/d/143eWKbtCsOtGyeXpLTMC_pyunIsSOkQxBcHDGxdjb7w/edit?tab=t.0).
Test for all test cases listed in the doc added to driver-example repo: [PR LINK](https://github.com/yugabyte/driver-examples/pull/46).
Ran the existing and new tests in driver examples repo for rust-postgres.